### PR TITLE
fix: Changed contact page title from activities to contact itself

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>RBJKS::Activities</title>
+    <title>RBJKS::Contact</title>
     <link rel="stylesheet" type="text/css" href="assets/css/style.css" />
     <link rel="stylesheet" type="text/css" href="assets/css/contact.css" />
     <link


### PR DESCRIPTION
This Change was required in order to find out the contact page is really contact page

Fixes #110

Description:-
I changed the title of the contact page from activities to contact

How I Tested?
I tested my changed by previewing the website

Screenshot:
![Screenshot 2024-03-25 105645](https://github.com/rbjks/rbjks.github.io/assets/151373021/26b55219-48af-4e85-9dca-0a53ee91b504)


